### PR TITLE
Add constructor to `Cookie` class. Fixes types/npm-tough-cookie#2

### DIFF
--- a/lib/cookie.d.ts
+++ b/lib/cookie.d.ts
@@ -120,6 +120,86 @@ export class Store {
 export class MemoryCookieStore extends Store {}
 
 /**
+ * Interface for the options of the Cookie constructor
+ */
+export interface CookieConstructorOptions {
+  /**
+   * the name or key of the cookie (default "")
+   */
+  key?: string;
+
+  /**
+   * the value of the cookie (default "")
+   */
+  value?: string;
+
+  /**
+   * if set, the Expires= attribute of the cookie (defaults to the string "Infinity").
+   * See setExpires()
+   */
+  expires?: Date;
+
+  /**
+   * (seconds) if set, the Max-Age= attribute in seconds of the cookie. May also
+   * be set to strings "Infinity" and "-Infinity" for non-expiry and immediate-expiry,
+   * respectively. See setMaxAge()
+   */
+  maxAge?: number;
+
+  /**
+   * the Domain= attribute of the cookie
+   */
+  domain?: string;
+
+  /**
+   * the Path= of the cookie
+   */
+  path?: string;
+
+  /**
+   * the Secure cookie flag
+   */
+  secure?: boolean;
+
+  /**
+   * the HttpOnly cookie flag
+   */
+  httpOnly?: boolean;
+
+  /**
+   * any unrecognized cookie attributes as strings (even if equal-signs inside)
+   */
+  extensions?: string[];
+
+  /**
+   * when this cookie was constructed
+   */
+  creation?: Date;
+
+  /**
+   * set at construction, used to provide greater sort precision
+   * (please see cookieCompare(a,b) for a full explanation)
+   */
+  creationIndex?: number;
+
+  /**
+   * is this a host-only cookie (i.e. no Domain field was set, but was instead implied)
+   */
+  hostOnly?: boolean;
+
+  /**
+   * if true, there was no Path field on the cookie and defaultPath() was used to derive one.
+   */
+  pathIsDefault?: boolean;
+
+  /**
+   * last time the cookie got accessed. Will affect cookie cleaning once
+   * implemented. Using cookiejar.getCookies(...) will update this attribute.
+   */
+  lastAccessed?: Date;
+}
+
+/**
  * Exported via tough.Cookie.
  */
 export class Cookie {
@@ -228,6 +308,12 @@ export class Cookie {
    * encode to a Cookie header value (i.e. the .key and .value properties joined with '=').
    */
   cookieString (): string;
+
+  /**
+   * Receives an options object that can contain any of the above Cookie properties, uses the
+   * default for unspecified properties.
+   */
+  constructor (options?: CookieConstructorOptions);
 
   /**
    * sets the expiry based on a date-string passed through parseDate(). If parseDate


### PR DESCRIPTION
This PR fixes #2.

It simply uses an interface `CookieConstructorOptions` to type the options of the constructor. This interfaces is a copy of the properties of the `Cookie` class, with the "optional" modifier. A better solution would be to use the new syntax for typed properties (Typescript 2.1) to not replicate the optional properties of the options and the defined properties of the class. TS2.1 is still a recent release and an overall update of these typings seems required anyway so the proposed quick fix is good enough for the moment.